### PR TITLE
Fix grade status triggers to use any() instead of all()

### DIFF
--- a/controller/data/Absence/AbsenceStatus.py
+++ b/controller/data/Absence/AbsenceStatus.py
@@ -24,7 +24,6 @@ class AbsenceStatus:
         for g in valid_grades:
             grade_counts[g] = grade_counts.get(g, 0) + 1
 
-
         perfectCon = conditionType['perfectCon']
 
         if not valid_grades:
@@ -32,11 +31,11 @@ class AbsenceStatus:
         elif valid_grades and all(g == perfectCon for g in valid_grades):
             # print("Perfect condition matched")
             status = self.perfect_msg
-        elif all(grade_counts.get(k, 0) >= v for k, v in conditionType['dismissCon'].items()):
+        elif any(grade_counts.get(k, 0) >= v for k, v in conditionType['dismissCon'].items()):
             status = self.dismiss_msg
-        elif all(grade_counts.get(k, 0) >= v for k, v in conditionType['riskCon'].items()):
+        elif any(grade_counts.get(k, 0) >= v for k, v in conditionType['riskCon'].items()):
             status = self.risk_msg
-        elif all(grade_counts.get(k, 0) >= v for k, v in conditionType['warnCon'].items()):
+        elif any(grade_counts.get(k, 0) >= v for k, v in conditionType['warnCon'].items()):
             status = self.improve_msg
         else:
             status = self.good_msg

--- a/controller/data/ETarget/TargetStatus.py
+++ b/controller/data/ETarget/TargetStatus.py
@@ -29,11 +29,11 @@ class TargetStatus:
             status = "no data"
         elif valid_grades and all(g ==  perfectCon for g in valid_grades):
             status = self.perfect_msg
-        elif all(grade_counts.get(k, 0) >= v for k, v in conditionType['dismissCon'].items()):
+        elif any(grade_counts.get(k, 0) >= v for k, v in conditionType['dismissCon'].items()):
             status = self.dismiss_msg
-        elif all(grade_counts.get(k, 0) >= v for k, v in conditionType['riskCon'].items()):
+        elif any(grade_counts.get(k, 0) >= v for k, v in conditionType['riskCon'].items()):
             status = self.risk_msg
-        elif all(grade_counts.get(k, 0) >= v for k, v in conditionType['warnCon'].items()):
+        elif any(grade_counts.get(k, 0) >= v for k, v in conditionType['warnCon'].items()):
             status = self.improve_msg
         else:
             status = self.good_msg


### PR DESCRIPTION
The logic was requiring all conditions to be met, when meeting any single condition should be sufficient to trigger a status change.